### PR TITLE
Add krashna.nl site to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Source: [https://github.com/wiziple/gatsby-plugin-intl/tree/master/examples/gats
 
 ## Showcase
 
-[https://picpick.app](https://picpick.app)
+- [https://picpick.app](https://picpick.app)
+- [https://www.krashna.nl](https://www.krashna.nl)
 
 *Feel free to send us PR to add your project.*
 


### PR DESCRIPTION
We've recently transitioned from i18n to gatsby-plugin-intl for internalization on our site, and I'd like to add this site to your showcase! We do YAML-based translation, which we merge into one big JSON file for gatsby-plugin-intl to use.

In this PR, I've also changed the showcase to a bullet-point list (to allow for easier extension with more sites), and the GitHub editor seems to have automatically added a newline at the end of the README.

The site I'm PRing is [krashna.nl](https://www.krashna.nl), and is [open-source](https://github.com/krashnamusika/krashna-site). We built and maintain this site for the student orchestra and choir association of Delft (The Netherlands), called Krashna Musika.

Thanks for the great plugin, it's been a timesaver!