### PR TITLE
fix: correctly set html lang attribute

### DIFF
--- a/examples/gatsby-starter-default-intl/src/components/layout.js
+++ b/examples/gatsby-starter-default-intl/src/components/layout.js
@@ -13,7 +13,7 @@ import { injectIntl } from "gatsby-plugin-intl"
 import Header from "./header"
 import "./layout.css"
 
-const Layout = ({ children, intl, pageContext }) => (
+const Layout = ({ children, intl }) => (
   <StaticQuery
     query={graphql`
       query SiteTitleQuery {
@@ -26,10 +26,7 @@ const Layout = ({ children, intl, pageContext }) => (
     `}
     render={data => (
       <>
-        <Header
-          siteTitle={intl.formatMessage({ id: "title" })}
-          htmlAttributes={{ lang: pageContext.intl.language }}
-        />
+        <Header siteTitle={intl.formatMessage({ id: "title" })} />
         <div
           style={{
             margin: `0 auto`,
@@ -48,11 +45,11 @@ const Layout = ({ children, intl, pageContext }) => (
       </>
     )}
   />
-);
+)
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,
-  pageContext: PropTypes.object.isRequired
-};
+  intl: PropTypes.object.isRequired,
+}
 
 export default injectIntl(Layout)

--- a/examples/gatsby-starter-default-intl/src/components/seo.js
+++ b/examples/gatsby-starter-default-intl/src/components/seo.js
@@ -89,8 +89,8 @@ SEO.defaultProps = {
 }
 
 SEO.propTypes = {
-  description: PropTypes.string,
   lang: PropTypes.string,
+  description: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
   keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,

--- a/examples/gatsby-starter-default-intl/src/pages/404.js
+++ b/examples/gatsby-starter-default-intl/src/pages/404.js
@@ -6,7 +6,10 @@ import SEO from "../components/seo"
 
 const NotFoundPage = ({ intl }) => (
   <Layout>
-    <SEO title={`404: ${intl.formatMessage({ id: "title" })}`} />
+    <SEO
+      lang={intl.locale}
+      title={`404: ${intl.formatMessage({ id: "title" })}`}
+    />
     <h1>
       <FormattedMessage id="notfound.header" />
     </h1>

--- a/examples/gatsby-starter-default-intl/src/pages/index.js
+++ b/examples/gatsby-starter-default-intl/src/pages/index.js
@@ -8,6 +8,7 @@ const IndexPage = ({ intl }) => {
   return (
     <Layout>
       <SEO
+        lang={intl.locale}
         title={intl.formatMessage({ id: "title" })}
         keywords={[`gatsby`, `application`, `react`]}
       />

--- a/examples/gatsby-starter-default-intl/src/pages/page-2.js
+++ b/examples/gatsby-starter-default-intl/src/pages/page-2.js
@@ -6,7 +6,7 @@ import SEO from "../components/seo"
 
 const SecondPage = ({ intl }) => (
   <Layout>
-    <SEO title={intl.formatMessage({ id: "title_page2" })} />
+    <SEO lang={intl.locale} title={intl.formatMessage({ id: "title_page2" })} />
     <h1>
       <FormattedMessage id="hello_page2" />
     </h1>


### PR DESCRIPTION
The right way to set html lang attribute in starter.
Because, as said here #28 `pageContext` prop is undefined inside `Layout` component.
