### PR TITLE
Include default language in locale data loading.

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,7 +1,10 @@
 const webpack = require("webpack")
 
 exports.onCreateWebpackConfig = ({ actions, plugins }, pluginOptions) => {
-  const { redirectComponent = null, languages } = pluginOptions
+  const { redirectComponent = null, languages, defaultLanguage } = pluginOptions
+  if (!languages.includes(defaultLanguage)) {
+    languages.push(defaultLanguage);
+  }
   const regex = new RegExp(languages.map(l => l.split("-")[0]).join("|"))
   actions.setWebpackConfig({
     plugins: [


### PR DESCRIPTION
A fix for this reported issue: https://github.com/wiziple/gatsby-plugin-intl/issues/36 

This covers the case where a second set of pages for the default language is not desirable. (Only wanting English to show up at `/` and not at `/en/` too.)