### PR TITLE
Make 404 matchPath optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ plugins: [
       defaultLanguage: `ko`,
       // option to redirect to `/ko` when connecting `/`
       redirect: true,
+      // option to generate language-specific 404 pages
+      generate404: true,
     },
   },
 ]
@@ -113,6 +115,7 @@ languages | string[] | supported language keys
 defaultLanguage | string | default language when visiting `/page` instead of `ko/page`
 redirect | boolean | if the value is `true`, `/` or `/page-2` will be redirected to the user's preferred language router. e.g) `/ko` or `/ko/page-2`. Otherwise, the pages will render `defaultLangugage` language.
 redirectComponent | string (Optional) | additional component file path to be rendered on with a redirection component for SEO.
+generate404 | boolean | If the value is true, language-specific 404 pages will be handled. For example, `/ko/missing-page` will show a Korean 404 page if this value is set to true. When this value is set to false, `/ko/missing-page` will show a 404 page in the default language.
 
 
 ## Components

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -41,6 +41,7 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
     languages = ["en"],
     defaultLanguage = "en",
     redirect = false,
+    generate404 = true,
   } = pluginOptions
 
   const getMessages = (path, language) => {
@@ -79,7 +80,7 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
 
   languages.forEach(language => {
     const localePage = generatePage(true, language)
-    if (localePage.path.includes(`/404/`)) {
+    if (generate404 && localePage.path.includes(`/404/`)) {
       localePage.matchPath = `/${language}/*`
     }
     createPage(localePage)


### PR DESCRIPTION
As a workaround to [the ongoing issue with `matchPath`](https://github.com/wiziple/gatsby-plugin-intl/issues/27), I am proposing that we make the 404 usage of `matchPath` an additional option for now so that those of us who would like to can take advantage of the additional gatsby fixes to the behavior of `matchPath` while they get to the root of this issue.