### PR TITLE
Skip already processed pages

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -37,6 +37,10 @@ exports.onCreateWebpackConfig = ({ actions, plugins }, pluginOptions) => {
 const allSitePage = []
 
 exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
+  //Exit if the page has already been processed.
+  if (typeof page.context.intl === "object") {
+    return
+  }
   const { createPage, deletePage } = actions
   const {
     path = ".",


### PR DESCRIPTION
Problem:
Every time you want to modify context of page that already been processed/generated by this plugin, you need to call `deletePage` and `createPage`. This causes plugin (`onCreatePage`) to process page again and create new pages.

Solution:
This commit adds simple check wether page was proccessed or not.