### PR TITLE
fix changeLocale to match pathnames without a forward slash

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -64,11 +64,14 @@ export const changeLocale = (language, to) => {
   }
 
   const pathname = to || removeLocalePart(window.location.pathname)
-  // TODO: check slash
+
   const link = `/${language}${pathname}${window.location.search}`
   localStorage.setItem("gatsby-intl-language", language)
 
-  if (allSitePage.includes(link)) {
+  if (
+    allSitePage.includes(`/${language}${pathname}`) ||
+    allSitePage.includes(`/${language}${pathname}/`)
+  ) {
     gatsbyNavigate(link)
   } else {
     gatsbyNavigate(`/${language}/`)


### PR DESCRIPTION
See issue [#52 ](https://github.com/wiziple/gatsby-plugin-intl/issues/51)
This change ensures that changing of the language does not fail because the pathname lacks a forward slash. The search query is also removed as this would also potentially prevent matching sitePages.