### PR TITLE
Fixed issue#18

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -37,6 +37,9 @@ exports.onCreateWebpackConfig = ({ actions, plugins }, pluginOptions) => {
 const allSitePage = []
 
 exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
+  if (page.context && page.context.intl) {
+    return
+  }
   const { createPage, deletePage } = actions
   const {
     path = ".",


### PR DESCRIPTION
and other potentially issues with any other plugins/themes that implements onCreatePage on gatsby-node.js.

It checks if the page has already a intl context property, which means this plugin already injected its props, so don't do it again, because onCreatePages is called again if there is another plugin / theme creating pages too.