### PR TITLE
Fix recursive page creation

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -37,6 +37,9 @@ exports.onCreateWebpackConfig = ({ actions, plugins }, pluginOptions) => {
 const allSitePage = []
 
 exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
+  if (page.context.intl) {
+    return;
+  }
   const { createPage, deletePage } = actions
   const {
     path = ".",


### PR DESCRIPTION
I'm creating pages after `intl` does its page creation.

Without this check `intl` runs again creating double nested language paths.

`my-page` redirects to `en/my-page` redirects to `en/en/my-page`.

Fixed in PR.
