### PR TITLE
Fix redirect & changeLocale with prefix path

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -55,6 +55,15 @@ export const changeLocale = (language, to) => {
   }
   const { routed } = window.___gatsbyIntl
 
+  const removePrefix = pathname => {
+    const base =
+      typeof __BASE_PATH__ !== `undefined` ? __BASE_PATH__ : __PATH_PREFIX__
+    if (base && pathname.indexOf(base) === 0) {
+      pathname = pathname.slice(base.length)
+    }
+    return pathname
+  }
+
   const removeLocalePart = pathname => {
     if (!routed) {
       return pathname
@@ -63,7 +72,8 @@ export const changeLocale = (language, to) => {
     return pathname.substring(i)
   }
 
-  const pathname = to || removeLocalePart(window.location.pathname)
+  const pathname =
+    to || removeLocalePart(removePrefix(window.location.pathname))
   // TODO: check slash
   const link = `/${language}${pathname}${window.location.search}`
   localStorage.setItem("gatsby-intl-language", language)

--- a/src/wrap-page.js
+++ b/src/wrap-page.js
@@ -43,7 +43,7 @@ export default ({ element, props }) => {
 
   const { pageContext, location } = props
   const { intl } = pageContext
-  const { language, languages, redirect, routed } = intl
+  const { language, languages, redirect, routed, originalPath } = intl
 
   if (typeof window !== "undefined") {
     window.___gatsbyIntl = intl
@@ -52,7 +52,7 @@ export default ({ element, props }) => {
   const isRedirect = redirect && !routed
 
   if (isRedirect) {
-    const { pathname, search } = location
+    const { search } = location
 
     // Skip build, Browsers only
     if (typeof window !== "undefined") {
@@ -68,7 +68,7 @@ export default ({ element, props }) => {
       }
 
       const queryParams = search || ""
-      const newUrl = withPrefix(`/${detected}${pathname}${queryParams}`)
+      const newUrl = withPrefix(`/${detected}${originalPath}${queryParams}`)
       window.localStorage.setItem("gatsby-intl-language", detected)
       window.location.replace(newUrl)
     }


### PR DESCRIPTION
I found the issue that redirect and `changeLocale` function are wrong when using gatsby's prefix path (like `/intl`).

redirect:
- Expected: `/intl/` -> `/intl/en/`
- Actual: `/intl/` -> `/intl/en/intl/`

`changeLocale` function (en -> de):
- Expected: `/intl/en/` -> `/intl/de/`
- Actual: `/intl/en/` -> `/intl/de/en/`

You can reproduce this problem with `gatsby-starter-default-intl` using this patch.

```diff
diff --git a/examples/gatsby-starter-default-intl/gatsby-config.js b/examples/gatsby-starter-default-intl/gatsby-config.js
index 24c6a80..165d2f7 100644
--- a/examples/gatsby-starter-default-intl/gatsby-config.js
+++ b/examples/gatsby-starter-default-intl/gatsby-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  pathPrefix: `/intl`,
   siteMetadata: {
     title: `Gatsby Default Starter`,
     description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
diff --git a/examples/gatsby-starter-default-intl/package.json b/examples/gatsby-starter-default-intl/package.json
index 403542a..88d9615 100644
--- a/examples/gatsby-starter-default-intl/package.json
+++ b/examples/gatsby-starter-default-intl/package.json
@@ -27,11 +27,11 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
-    "serve": "gatsby serve",
+    "serve": "gatsby serve --prefix-paths",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
   },
   "repository": {
```

and run: `$ yarn build && yarn serve && open http://localhost:9000/intl/`