### PR TITLE
Export IntlContextProvider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export * from "react-intl"
 export { default as Link, navigate, changeLocale } from "./link"
 export { default as withIntl } from "./with-intl"
-export { IntlContextConsumer } from "./intl-context"
+export { IntlContextProvider, IntlContextConsumer } from "./intl-context"


### PR DESCRIPTION
I think exporting IntlContextProvider can be quite useful, even though not necessary for most users. Example use case where it is useful (this was the case for me) is for Storybook, where the provider is not automatically added like it is with Gatsby.