### PR TITLE
Create Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,12 @@
+declare module 'gatsby-plugin-intl' {
+  import * as gatsby from 'gatsby';
+  import React from 'react';
+
+  export * from 'react-intl';
+
+  export class Link<TState> extends gatsby.Link<TState> {}
+  export const navigate: typeof gatsby.navigate;
+  export const changeLocale: (language: string, to?: string) => void;
+  export const IntlContextProvider: React.Provider;
+  export const IntlContextConsumer: React.Consumer;
+}


### PR DESCRIPTION
Declaring a module and typings to be able to use the plugin with a Typescript enabled gatsby project.