### PR TITLE
Fix Typescript Definition errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,15 @@ declare module 'gatsby-plugin-intl' {
   export class Link<TState> extends gatsby.Link<TState> {}
   export const navigate: typeof gatsby.navigate;
   export const changeLocale: (language: string, to?: string) => void;
-  export const IntlContextProvider: React.Provider<any>;
-  export const IntlContextConsumer: React.Consumer<any>;
+  
+  import { IntlShape } from "react-intl";
+  interface GatsbyPluginIntlShape extends IntlShape {
+    language: string;
+    languages: string[];
+    routed: boolean;
+    originalPath: string;
+    redirect: boolean;
+  }
+  export const IntlContextProvider: React.Provider<GatsbyPluginIntlShape>;
+  export const IntlContextConsumer: React.Consumer<GatsbyPluginIntlShape>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,6 @@ declare module 'gatsby-plugin-intl' {
   export class Link<TState> extends gatsby.Link<TState> {}
   export const navigate: typeof gatsby.navigate;
   export const changeLocale: (language: string, to?: string) => void;
-  export const IntlContextProvider: React.Provider;
-  export const IntlContextConsumer: React.Consumer;
+  export const IntlContextProvider: React.Provider<any>;
+  export const IntlContextConsumer: React.Consumer<any>;
 }


### PR DESCRIPTION
I am getting these errors when running typecheck in a project using this plugin.

```
node_modules/gatsby-plugin-intl/index.d.ts:10:37 - error TS2314: Generic type 'Provider' requires type argument(s).

export const IntlContextProvider: React.Provider;

node_modules/gatsby-plugin-intl/index.d.ts:11:37 - error TS2314: Generic type 'Consumer' requires 1 type argument(s).

export const IntlContextConsumer: React.Consumer;

Generic type 'Provider' requires 1 type argument(s).
Generic type 'Consumer' requires 1 type argument(s).
```

I provided an argument to fix them
