### PR TITLE
Add ability to keep the messages in a .js file or in a module

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,4 +1,5 @@
 const webpack = require("webpack")
+const fs = require('fs')
 
 function flattenMessages(nestedMessages, prefix = "") {
   return Object.keys(nestedMessages).reduce((messages, key) => {
@@ -53,8 +54,17 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
 
   const getMessages = (path, language) => {
     try {
-      // TODO load yaml here
-      const messages = require(`${path}/${language}.json`)
+
+      let messages;
+
+
+      if(fs.existsSync(`${path}/${language}.json`))
+        messages = require(`${path}/${language}.json`)
+      else if(fs.existsSync(`${path}/${language}/index.js`))
+        messages = require(`${path}/${language}/index.js`)
+      else
+        messages = require(`${path}/${language}.js`)
+      
 
       return flattenMessages(messages)
     } catch (error) {


### PR DESCRIPTION
This will allow the frequently requested feature of splitting the translations into many files, which is very helpful if your site gets really large. And you can do some logic in the translations at compile-time. 
It prefers .json files over the modules in order to be backwards compatible.