### PR TITLE
Allow single-language pages

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -91,6 +91,19 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
     }
   }
 
+  // get first dir name
+  const [_, pageDir] = page.path.match(/^\/([^\/]*)/) || []
+
+  // if it matches an intl language
+  // this page will be opted out of additional page generation
+  if (languages.includes(pageDir)) {
+    // recreate the page as is but with correct language context
+    const newPage = generatePage(false, pageDir)
+    deletePage(page)
+    createPage(newPage)
+    return
+  }
+
   const newPage = generatePage(false, defaultLanguage)
   deletePage(page)
   createPage(newPage)


### PR DESCRIPTION
This is a PR to allow single-language pages.

The problem:
My site's `intl` is defined with 2 languages but a some pages are only in one language (for instance a page for a conference offered for English speakers only, therefore irrelevant to translate to additional locales).

But there is no way to indicate to the plugin that a certain page should "opt out" of all language page generation.

The solution:
Defining a page in a directory with the language name is easy and clear.
Here's an example:
```
// languages - en + es
|-- /src
    |-- /pages
        |-- foo.jsx      <-- normal: generates /foo, /en/foo, /es/foo
        |-- a/bar.jsx    <-- normal: generates /a/bar, /a/en/bar, a/es/bar
        |-- en/baz.jsx   <-- single language: generates en/baz only 🔥
```

Related to  #152.