### PR TITLE
fix formatjs's paths to local-data to reduce bundle size

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -27,11 +27,11 @@ exports.onCreateWebpackConfig = ({ actions, plugins }, pluginOptions) => {
         GATSBY_INTL_REDIRECT_COMPONENT_PATH: JSON.stringify(redirectComponent),
       }),
       new webpack.ContextReplacementPlugin(
-        /@formatjs[/\\]intl-relativetimeformat[/\\]dist[/\\]locale-data$/,
+        /@formatjs[/\\]intl-relativetimeformat[/\\]locale-data$/,
         regex
       ),
       new webpack.ContextReplacementPlugin(
-        /@formatjs[/\\]intl-pluralrules[/\\]dist[/\\]locale-data$/,
+        /@formatjs[/\\]intl-pluralrules[/\\]locale-data$/,
         regex
       ),
     ],


### PR DESCRIPTION
fixes https://github.com/wiziple/gatsby-plugin-intl/issues/232