### PR TITLE
feat(gatsbynode): add onlyLanguages option

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -91,11 +91,19 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
     }
   }
 
-  const newPage = generatePage(false, defaultLanguage)
+  const options = page.context.gatsbyPluginIntl || {}
+  const onlyLanguages = options.onlyLanguages || []
+
   deletePage(page)
-  createPage(newPage)
+
+  if (onlyLanguages.length === 0 || onlyLanguages.includes(defaultLanguage)) {
+    const newPage = generatePage(false, defaultLanguage)
+    createPage(newPage)
+  }
 
   languages.forEach((language) => {
+    if (onlyLanguages.length > 0 && !onlyLanguages.includes(language))
+      return;
     const localePage = generatePage(true, language)
     const regexp = new RegExp("/404/?$")
     if (regexp.test(localePage.path)) {


### PR DESCRIPTION
https://github.com/wiziple/gatsby-plugin-intl/issues/33 is a great idea to permit localized URLs.

This is a simpler version that does not require slugs to be defined in `react-intl` message files (e.g. `en.json` ...etc).

This change adds the possibility to limit page generation to certain languages only.

For example, if creating pages dynamically (e.g. from a CMS or the MDX plugin like in ), you can pass a parameter through the page context to ensure only one version of the page is created.

It makes sense to me to nest this option inside a `gatsbyPluginIntl` to allow for further options to be passed in this manner.

```
const language = `fr`;
createPage({
  path,
  component: template,
  context: {
    id: node.id,
    language,
    gatsbyPluginIntl: {
      onlyLanguages: [language]
    },
  },
});
```